### PR TITLE
fix: declare package repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,14 @@
   ],
   "author": "",
   "license": "ISC",
+  "homepage": "https://github.com/MehmetSecgin/dispatch#readme",
+  "bugs": {
+    "url": "https://github.com/MehmetSecgin/dispatch/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/MehmetSecgin/dispatch"
+  },
   "type": "module",
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary
- add repository, homepage, and bugs metadata to package.json so npm provenance matches the GitHub repo
- follow up on the failed trusted-publishing run after PR #37

## Validation
- npm pkg get repository homepage bugs
- npm pack --dry-run