### PR TITLE
feat: per-step http override in job cases (Slice 5)

### DIFF
--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -43,6 +43,11 @@ const JobInputSchema = z.object({
   description: z.string().min(1).optional(),
 });
 
+const JobHttpSchema = z.object({
+  baseUrl: z.string().min(1).optional(),
+  defaultHeaders: z.record(z.string(), z.string()).optional(),
+});
+
 const StepSchema = z
   .object({
     id: z.string().min(1).optional(),
@@ -52,6 +57,7 @@ const StepSchema = z
     payload: z.record(z.string(), z.unknown()).optional(),
     capture: StepCaptureSchema.optional(),
     credential: z.string().min(1).optional(),
+    http: JobHttpSchema.optional(),
   })
   .superRefine((v, ctx) => {
     if (v.atRelative && v.atAbsolute) {
@@ -83,11 +89,6 @@ const JobDependenciesSchema = z.object({
   modules: z.array(ModuleDependencySchema).optional(),
   memory: z.array(MemoryDependencySchema).optional(),
   http: HttpDependencySchema.optional(),
-});
-
-const JobHttpSchema = z.object({
-  baseUrl: z.string().min(1).optional(),
-  defaultHeaders: z.record(z.string(), z.string()).optional(),
 });
 
 export const JobCaseSchema = z.object({
@@ -172,6 +173,15 @@ export interface JobStep {
    * handler runs and exposes the resulting object at `ctx.credential`.
    */
   credential?: string;
+
+  /**
+   * Optional per-step HTTP override.
+   *
+   * Deep-merged over the job-level `http` block at runtime: `baseUrl` is
+   * replaced wholesale, `defaultHeaders` are shallow-merged (step-level
+   * keys win, unrelated job-level keys are preserved).
+   */
+  http?: JobHttpConfig;
 }
 
 export function normalizeSteps(job: JobCase): JobStep[] {

--- a/src/job/dependencies.ts
+++ b/src/job/dependencies.ts
@@ -185,26 +185,65 @@ function hasOwnPath(obj: unknown, pathSpec: string): boolean {
   return true;
 }
 
+function mergeStepHttp(
+  jobHttp: JobHttpConfig | undefined,
+  stepHttp: JobHttpConfig | undefined,
+): JobHttpConfig | undefined {
+  if (!jobHttp && !stepHttp) return undefined;
+  const merged: JobHttpConfig = {};
+  const baseUrl = stepHttp?.baseUrl ?? jobHttp?.baseUrl;
+  if (baseUrl !== undefined) merged.baseUrl = baseUrl;
+  const jobHeaders = jobHttp?.defaultHeaders;
+  const stepHeaders = stepHttp?.defaultHeaders;
+  if (jobHeaders || stepHeaders) {
+    const headers: Record<string, string> = {};
+    if (jobHeaders) for (const [k, v] of Object.entries(jobHeaders)) headers[k] = v;
+    if (stepHeaders) for (const [k, v] of Object.entries(stepHeaders)) headers[k] = v;
+    merged.defaultHeaders = headers;
+  }
+  return merged;
+}
+
 export function inspectHttpDependencies(
   job: JobCase,
   effectiveHttp?: JobHttpConfig,
 ): Pick<DependencyCheckResult, 'issues' | 'valid'> {
   const issues: DependencyIssue[] = [];
   const requiredPaths = job.dependencies?.http?.required ?? [];
-  const resolvedHttp = effectiveHttp ?? job.http;
-  for (const pathSpec of requiredPaths) {
-    if (hasOwnPath(resolvedHttp, pathSpec)) continue;
-    issues.push({
-      code: 'MISSING_HTTP_DEPENDENCY',
-      dependencyType: 'http',
-      httpPath: pathSpec,
-      message: `Missing required HTTP config http.${pathSpec}`,
-    });
+  if (requiredPaths.length === 0) return { valid: true, issues };
+
+  const resolvedJobHttp = effectiveHttp ?? job.http;
+  const steps = job.scenario.steps;
+  const anyStepOverride = steps.some((step) => step.http);
+
+  if (!anyStepOverride) {
+    for (const pathSpec of requiredPaths) {
+      if (hasOwnPath(resolvedJobHttp, pathSpec)) continue;
+      issues.push({
+        code: 'MISSING_HTTP_DEPENDENCY',
+        dependencyType: 'http',
+        httpPath: pathSpec,
+        message: `Missing required HTTP config http.${pathSpec}`,
+      });
+    }
+    return { valid: issues.length === 0, issues };
   }
-  return {
-    valid: issues.length === 0,
-    issues,
-  };
+
+  for (let idx = 0; idx < steps.length; idx += 1) {
+    const step = steps[idx];
+    const stepId = step.id ?? `step_${idx + 1}`;
+    const merged = mergeStepHttp(resolvedJobHttp, step.http);
+    for (const pathSpec of requiredPaths) {
+      if (hasOwnPath(merged, pathSpec)) continue;
+      issues.push({
+        code: 'MISSING_HTTP_DEPENDENCY',
+        dependencyType: 'http',
+        httpPath: pathSpec,
+        message: `Missing required HTTP config http.${pathSpec} for step ${stepId}`,
+      });
+    }
+  }
+  return { valid: issues.length === 0, issues };
 }
 
 export function resolveEffectiveJobHttpConfig(

--- a/src/job/runner.ts
+++ b/src/job/runner.ts
@@ -156,9 +156,17 @@ export async function executeJobCase(
       throw new Error(`Validation failed for ${step.action}: ${errors.join('; ')}`);
     }
 
+    const stepHttpOverride = resolveStepHttpConfig(step.http, runtime, step.id);
+    const stepHttp = stepHttpOverride
+      ? http.withDefaults({
+          baseUrl: stepHttpOverride.baseUrl,
+          defaultHeaders: stepHttpOverride.defaultHeaders,
+        })
+      : http;
+
     const result = await resolved.definition.handler(
       {
-        http,
+        http: stepHttp,
         artifacts,
         runtime,
         step,
@@ -456,6 +464,40 @@ export function resolveJobHttpConfig(
     for (const [name, value] of Object.entries(resolved.defaultHeaders)) {
       if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
         throw new Error(`Job http.defaultHeaders.${name} must resolve to a string-compatible scalar`);
+      }
+      defaultHeaders[name] = String(value);
+    }
+    out.defaultHeaders = defaultHeaders;
+  }
+
+  return out;
+}
+
+export function resolveStepHttpConfig(
+  httpConfig: JobHttpConfig | undefined,
+  runtime: RuntimeContext,
+  stepId: string,
+): JobHttpConfig | undefined {
+  if (!httpConfig) return undefined;
+  const resolved = interpolateAny(httpConfig, runtime);
+  if (!isJsonObject(resolved)) throw new Error(`Step ${stepId} http config must resolve to an object`);
+
+  const out: JobHttpConfig = {};
+  if (resolved.baseUrl !== undefined) {
+    if (typeof resolved.baseUrl !== 'string' || resolved.baseUrl.trim().length === 0) {
+      throw new Error(`Step ${stepId} http.baseUrl must resolve to a non-empty string`);
+    }
+    out.baseUrl = resolved.baseUrl;
+  }
+
+  if (resolved.defaultHeaders !== undefined) {
+    if (!isJsonObject(resolved.defaultHeaders)) {
+      throw new Error(`Step ${stepId} http.defaultHeaders must resolve to an object`);
+    }
+    const defaultHeaders: Record<string, string> = {};
+    for (const [name, value] of Object.entries(resolved.defaultHeaders)) {
+      if (typeof value !== 'string' && typeof value !== 'number' && typeof value !== 'boolean') {
+        throw new Error(`Step ${stepId} http.defaultHeaders.${name} must resolve to a string-compatible scalar`);
       }
       defaultHeaders[name] = String(value);
     }

--- a/src/job/validator.ts
+++ b/src/job/validator.ts
@@ -333,6 +333,25 @@ export function validateJobCase(
         allowJsonPathStepScope: true,
       });
     });
+
+    if (step.http) {
+      traverseStrings(
+        step.http,
+        (s, strPath) => {
+          validateInterpolationString({
+            value: s,
+            path: strPath,
+            stepId: step.id,
+            declaredInputs: new Set(Object.keys(job.inputs ?? {})),
+            issues,
+            stepIndex,
+            allowStepReferences: false,
+            allowJsonPathStepScope: false,
+          });
+        },
+        'http',
+      );
+    }
   }
 
   traverseStrings(

--- a/test/job-validator.test.ts
+++ b/test/job-validator.test.ts
@@ -421,6 +421,66 @@ describe('validateJobCase (flow-only)', () => {
     expect(result.issues.some(i => i.code === 'DISALLOWED_MEMORY_MUTATION')).toBe(true);
   });
 
+  it('accepts step-level http override with env interpolation', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'step-http-override',
+      http: {
+        baseUrl: '${env.DISPATCH_PRIMARY_BASE_URL}',
+      },
+      scenario: {
+        steps: [
+          { id: 'publish', action: 'flow.sleep', payload: { duration: '1s' } },
+          {
+            id: 'assign',
+            action: 'flow.sleep',
+            payload: { duration: '1s' },
+            http: {
+              baseUrl: '${env.DISPATCH_SECONDARY_BASE_URL}',
+              defaultHeaders: {
+                'x-brand': '${env.DISPATCH_BRAND}',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = validateJobCase(job);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('rejects step interpolation inside step http config', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'step-http-step-ref',
+      scenario: {
+        steps: [
+          { id: 'publish', action: 'flow.sleep', payload: { duration: '1s' } },
+          {
+            id: 'assign',
+            action: 'flow.sleep',
+            payload: { duration: '1s' },
+            http: {
+              defaultHeaders: {
+                'x-id': '${step.publish.exports.generatedId}',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = validateJobCase(job);
+    expect(result.valid).toBe(false);
+    expect(
+      result.issues.some(
+        (i) => i.code === 'INVALID_INTERPOLATION' && i.path === 'http.defaultHeaders.x-id' && i.stepId === 'assign',
+      ),
+    ).toBe(true);
+  });
+
   it('allows memory.store in seed jobs', () => {
     const job = parseJob({
       schemaVersion: 1,

--- a/test/step-http-override.test.ts
+++ b/test/step-http-override.test.ts
@@ -1,0 +1,235 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { JobCaseSchema } from '../src/core/schema.ts';
+import { inspectHttpDependencies } from '../src/job/dependencies.ts';
+import { resolveStepHttpConfig } from '../src/job/runner.ts';
+import type { RuntimeContext } from '../src/execution/interpolation.ts';
+
+function parseJob(input: unknown) {
+  return JobCaseSchema.parse(input);
+}
+
+function makeRuntime(): RuntimeContext {
+  return {
+    configDir: '/tmp/dispatch-test',
+    input: {},
+    run: { startedAt: '2026-05-18T00:00:00Z' },
+    steps: {},
+  } as unknown as RuntimeContext;
+}
+
+const ENV_KEYS = ['DISPATCH_SECONDARY_BASE_URL', 'DISPATCH_BRAND', 'UNSET_FOR_TEST'];
+const savedEnv: Record<string, string | undefined> = {};
+for (const k of ENV_KEYS) savedEnv[k] = process.env[k];
+
+afterEach(() => {
+  for (const k of ENV_KEYS) {
+    if (savedEnv[k] === undefined) delete process.env[k];
+    else process.env[k] = savedEnv[k];
+  }
+});
+
+describe('step-level http override — schema', () => {
+  it('accepts a step with its own http baseUrl and headers', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'cross-host',
+      http: { baseUrl: 'http://localhost:8080' },
+      scenario: {
+        steps: [
+          { id: 'publish', action: 'mod-a.publish', payload: {} },
+          {
+            id: 'assign',
+            action: 'mod-b.assign',
+            payload: {},
+            http: {
+              baseUrl: 'https://api-b.example.test',
+              defaultHeaders: { 'x-brand': 'brand-b' },
+            },
+          },
+        ],
+      },
+    });
+
+    expect(job.scenario.steps[1].http?.baseUrl).toBe('https://api-b.example.test');
+    expect(job.scenario.steps[1].http?.defaultHeaders?.['x-brand']).toBe('brand-b');
+  });
+});
+
+describe('inspectHttpDependencies — per-step merge', () => {
+  it('passes when job-level provides all required paths and no step overrides', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'single-host',
+      http: {
+        baseUrl: 'http://localhost:8080',
+        defaultHeaders: { 'x-brand': 'brand-a' },
+      },
+      dependencies: { http: { required: ['baseUrl', 'defaultHeaders.x-brand'] } },
+      scenario: {
+        steps: [{ id: 's1', action: 'mod-a.publish', payload: {} }],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    expect(result.valid).toBe(true);
+    expect(result.issues).toHaveLength(0);
+  });
+
+  it('fails when job-level lacks required path and no step overrides', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'missing-brand',
+      http: { baseUrl: 'http://localhost:8080' },
+      dependencies: { http: { required: ['defaultHeaders.x-brand'] } },
+      scenario: {
+        steps: [{ id: 's1', action: 'mod-a.publish', payload: {} }],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    expect(result.valid).toBe(false);
+    expect(result.issues[0]).toMatchObject({
+      code: 'MISSING_HTTP_DEPENDENCY',
+      httpPath: 'defaultHeaders.x-brand',
+    });
+    expect(result.issues[0].message).not.toContain('for step');
+  });
+
+  it('passes when step-level override supplies the missing required path', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'step-supplies-baseurl',
+      dependencies: { http: { required: ['baseUrl', 'defaultHeaders.x-brand'] } },
+      scenario: {
+        steps: [
+          {
+            id: 'assign',
+            action: 'mod-b.assign',
+            payload: {},
+            http: {
+              baseUrl: 'https://api-b.example.test',
+              defaultHeaders: { 'x-brand': 'brand-b' },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    expect(result.valid).toBe(true);
+  });
+
+  it('keeps job-level header when a step overrides only baseUrl', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'cross-host-keeps-job-brand',
+      http: {
+        baseUrl: 'http://localhost:8080',
+        defaultHeaders: { 'x-brand': 'brand-a' },
+      },
+      dependencies: { http: { required: ['baseUrl', 'defaultHeaders.x-brand'] } },
+      scenario: {
+        steps: [
+          { id: 'publish', action: 'mod-a.publish', payload: {} },
+          {
+            id: 'assign',
+            action: 'mod-b.assign',
+            payload: {},
+            http: { baseUrl: 'https://api-b.example.test' },
+          },
+        ],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    // Job-level x-brand survives the shallow merge for the second step.
+    expect(result.valid).toBe(true);
+  });
+
+  it('keeps job-level header when a step provides unrelated defaultHeaders', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'cross-host-overrides-headers-without-brand',
+      http: {
+        baseUrl: 'http://localhost:8080',
+        defaultHeaders: { 'x-brand': 'brand-a' },
+      },
+      dependencies: { http: { required: ['defaultHeaders.x-brand'] } },
+      scenario: {
+        steps: [
+          {
+            id: 'assign',
+            action: 'mod-b.assign',
+            payload: {},
+            http: {
+              baseUrl: 'https://api-b.example.test',
+              defaultHeaders: { 'x-other': 'value' },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    // Shallow merge keeps unrelated job-level keys.
+    expect(result.valid).toBe(true);
+  });
+
+  it('flags a step whose merged http is missing a required path with step id in the message', () => {
+    const job = parseJob({
+      schemaVersion: 1,
+      jobType: 'step-missing-required-path',
+      // Job has no baseUrl; only the first step sets it.
+      dependencies: { http: { required: ['baseUrl'] } },
+      scenario: {
+        steps: [
+          {
+            id: 'publish',
+            action: 'mod-a.publish',
+            payload: {},
+            http: { baseUrl: 'http://localhost:8080' },
+          },
+          { id: 'follow-up', action: 'flow.sleep', payload: { duration: '1s' } },
+        ],
+      },
+    });
+
+    const result = inspectHttpDependencies(job);
+    expect(result.valid).toBe(false);
+    const missing = result.issues.find((i) => i.httpPath === 'baseUrl');
+    expect(missing?.message).toContain('for step follow-up');
+  });
+});
+
+describe('resolveStepHttpConfig — interpolation', () => {
+  it('returns undefined when no step http', () => {
+    expect(resolveStepHttpConfig(undefined, makeRuntime(), 's1')).toBeUndefined();
+  });
+
+  it('resolves env interpolation in baseUrl', () => {
+    process.env.DISPATCH_SECONDARY_BASE_URL = 'https://example.test';
+    const out = resolveStepHttpConfig(
+      { baseUrl: '${env.DISPATCH_SECONDARY_BASE_URL}' },
+      makeRuntime(),
+      's1',
+    );
+    expect(out?.baseUrl).toBe('https://example.test');
+  });
+
+  it('throws with step id when baseUrl resolves to empty', () => {
+    delete process.env.UNSET_FOR_TEST;
+    expect(() =>
+      resolveStepHttpConfig({ baseUrl: '${env.UNSET_FOR_TEST}' }, makeRuntime(), 'assign'),
+    ).toThrow(/Step assign http\.baseUrl/);
+  });
+
+  it('resolves env interpolation in defaultHeaders values', () => {
+    process.env.DISPATCH_BRAND = 'brand-a';
+    const out = resolveStepHttpConfig(
+      { defaultHeaders: { 'x-brand': '${env.DISPATCH_BRAND}' } },
+      makeRuntime(),
+      's1',
+    );
+    expect(out?.defaultHeaders?.['x-brand']).toBe('brand-a');
+  });
+});


### PR DESCRIPTION
## Summary

Slice 5 from the dispatch / dispatch-hub Agent UX rework.

- Step schema gains an optional `http` block with the same shape as the job-level one.
- At runtime each step derives an `HttpTransport` via `withDefaults`: `baseUrl` is replaced, `defaultHeaders` shallow-merge over job-level (cookie jar + connection pools stay shared).
- `dispatch job validate` now validates step-level `http` interpolation the same way it validates job-level `http` (no step references; env / input / run only).
- `dependencies.http.required` is satisfied per step against the merged (job + step) http config; failures name the offending step id.
- Pre-existing jobs that only use job-level `http` are untouched.

Collapses cross-host job authoring (one step publishes against host A, a later step assigns against host B) from two job files into one and lets captured values flow naturally to the cross-host step.

## Test plan

- [x] `npm run check` (tsc)
- [x] `npm run build` (tsup + public surface check)
- [x] `npx vitest run --exclude '.claude/**'` — 241/241 pass
- [x] New unit tests: `test/step-http-override.test.ts` (schema acceptance, per-step dep merge, interpolation/error paths)
- [x] New validator cases in `test/job-validator.test.ts` (env interpolation accepted in step.http, step references rejected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)