### PR TITLE
chore: rename admin-flavored examples and fixtures to generic auth names

### DIFF
--- a/schemas/module.json.schema.json
+++ b/schemas/module.json.schema.json
@@ -51,7 +51,7 @@
       "entry": "dist/index.mjs"
     },
     {
-      "name": "admin",
+      "name": "auth",
       "version": "0.1.0",
       "entry": "index.mjs",
       "metadata": {

--- a/src/modules/types.ts
+++ b/src/modules/types.ts
@@ -74,8 +74,8 @@ export interface DispatchModule {
   /**
    * Module namespace prefix.
    *
-   * If the name is `admin`, an action declared as `login` is resolved as
-   * `admin.login`.
+   * If the name is `auth`, an action declared as `login` is resolved as
+   * `auth.login`.
    *
    * This must match `module.json.name`.
    */
@@ -262,7 +262,7 @@ export interface ActionContext {
 
   /**
    * Resolve another action by its fully qualified key, such as
-   * `flow.poll` or `admin.login`.
+   * `flow.poll` or `auth.login`.
    *
    * Returns `null` when no loaded module provides that action.
    */
@@ -284,7 +284,7 @@ export interface ActionContext {
  * after layer precedence is applied.
  */
 export interface ResolvedAction {
-  /** Fully qualified action key, for example `admin.login`. */
+  /** Fully qualified action key, for example `auth.login`. */
   actionKey: string;
   /** Module namespace that owns the action. */
   moduleName: string;

--- a/test/authoring/credentials.test.ts
+++ b/test/authoring/credentials.test.ts
@@ -15,14 +15,14 @@ function makeCtx(credential?: unknown): ActionContext {
 
 describe('requireCredential', () => {
 	it('returns the credential when present', () => {
-		const cred = { username: 'admin', password: 'secret' };
-		const result = requireCredential<typeof cred>(makeCtx(cred), 'admin.login');
+		const cred = { username: 'user', password: 'secret' };
+		const result = requireCredential<typeof cred>(makeCtx(cred), 'auth.login');
 		expect(result).toBe(cred);
 	});
 
 	it('throws with action name when credential is missing', () => {
-		expect(() => requireCredential(makeCtx(), 'admin.login')).toThrow(
-			'admin.login requires a bound credential profile'
+		expect(() => requireCredential(makeCtx(), 'auth.login')).toThrow(
+			'auth.login requires a bound credential profile'
 		);
 	});
 

--- a/test/job-cli.test.ts
+++ b/test/job-cli.test.ts
@@ -1159,10 +1159,10 @@ describe('job CLI', () => {
           schemaVersion: 1,
           jobType: 'credential-profile',
           credentials: {
-            adminQa: {
+            apiCreds: {
               fromEnv: {
-                username: 'DISPATCH_ADMIN_USERNAME',
-                password: 'DISPATCH_ADMIN_PASSWORD',
+                username: 'DISPATCH_API_USERNAME',
+                password: 'DISPATCH_API_PASSWORD',
               },
             },
           },
@@ -1171,7 +1171,7 @@ describe('job CLI', () => {
               {
                 id: 'login',
                 action: `${HTTP_FIXTURE_MODULE_NAME}.login`,
-                credential: 'adminQa',
+                credential: 'apiCreds',
                 payload: {},
               },
             ],
@@ -1184,8 +1184,8 @@ describe('job CLI', () => {
     );
 
     const result = runCli(['job', 'run', '--case', path.relative(REPO_ROOT, casePath)], {
-      DISPATCH_ADMIN_USERNAME: 'demo-user',
-      DISPATCH_ADMIN_PASSWORD: 'demo-pass',
+      DISPATCH_API_USERNAME: 'demo-user',
+      DISPATCH_API_PASSWORD: 'demo-pass',
     });
 
     expect(result.status).toBe(0);
@@ -1195,8 +1195,8 @@ describe('job CLI', () => {
     }));
 
     const inputCase = JSON.parse(fs.readFileSync(path.join(result.json?.runDir, 'job.case.input.json'), 'utf8'));
-    expect(inputCase.credentials.adminQa.fromEnv).toEqual({
-      username: 'DISPATCH_ADMIN_USERNAME',
+    expect(inputCase.credentials.apiCreds.fromEnv).toEqual({
+      username: 'DISPATCH_API_USERNAME',
       password: '[REDACTED]',
     });
   });
@@ -1247,10 +1247,10 @@ describe('job CLI', () => {
           schemaVersion: 1,
           jobType: 'missing-credential-env',
           credentials: {
-            adminQa: {
+            apiCreds: {
               fromEnv: {
-                username: 'DISPATCH_ADMIN_USERNAME',
-                password: 'DISPATCH_ADMIN_PASSWORD',
+                username: 'DISPATCH_API_USERNAME',
+                password: 'DISPATCH_API_PASSWORD',
               },
             },
           },
@@ -1259,7 +1259,7 @@ describe('job CLI', () => {
               {
                 id: 'login',
                 action: `${HTTP_FIXTURE_MODULE_NAME}.login`,
-                credential: 'adminQa',
+                credential: 'apiCreds',
                 payload: {},
               },
             ],
@@ -1272,7 +1272,7 @@ describe('job CLI', () => {
     );
 
     const result = runCli(['job', 'run', '--case', path.relative(REPO_ROOT, casePath)], {
-      DISPATCH_ADMIN_USERNAME: 'demo-user',
+      DISPATCH_API_USERNAME: 'demo-user',
     });
 
     expect(result.status).toBe(2);
@@ -1283,7 +1283,7 @@ describe('job CLI', () => {
       details: expect.objectContaining({
         issues: expect.arrayContaining([
           expect.objectContaining({
-            message: expect.stringContaining("Missing required environment variable 'DISPATCH_ADMIN_PASSWORD'"),
+            message: expect.stringContaining("Missing required environment variable 'DISPATCH_API_PASSWORD'"),
           }),
         ]),
       }),


### PR DESCRIPTION
## Summary

The shipped CLI has no admin module — only `flow` and `memory` are built in. JSDoc examples, the `module.json` schema example, and credential/login test fixtures inherited an `admin` flavor that no longer reflects what the framework ships. Rename them to generic `auth` / `apiCreds` so the public surface reads cleanly without any inherited domain coupling.

### Changes

- `src/modules/types.ts` — JSDoc `admin.login` → `auth.login` (3 spots).
- `schemas/module.json.schema.json` — example `"name": "admin"` → `"name": "auth"`.
- `test/authoring/credentials.test.ts` — fixture action `admin.login` → `auth.login`, sample credential username `admin` → `user`.
- `test/job-cli.test.ts` — credential profile name `adminQa` → `apiCreds` and the matching env vars `DISPATCH_ADMIN_USERNAME` / `DISPATCH_ADMIN_PASSWORD` → `DISPATCH_API_USERNAME` / `DISPATCH_API_PASSWORD`.

No runtime behavior change. Schema, type contracts, CLI surface unchanged.

## Test plan

- [x] `npm run check` (tsc)
- [x] `npm run build` (tsup + public surface check)
- [x] `npx vitest run --exclude '.claude/**'` — 228/228 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)