### PR TITLE
feat: persistent cookie jar for dispatch run

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,29 @@ Written on both success and failure. Assert offline. Replay without network.
 
 ## Commands
 
+### Run (one action)
+
+```bash
+dispatch run <module.action> [--input <key=value>] [--base-url <url>] \
+  [--header <key=value>] [--credential <field=ENV_VAR>] \
+  [--session <name> | --cookie-jar <path>] [--clear-session]
+```
+
+`--session <name>` persists the action's cookie jar at
+`$DISPATCH_HOME/sessions/<name>/cookies.json` (mode `0600`, directory `0700`).
+The next `dispatch run` with the same `--session` reuses it, so a one-shot
+login call can carry its session into later read-only calls:
+
+```bash
+dispatch run my-module.login --credential token=API_TOKEN --session demo
+dispatch run my-module.get-thing --input id=42 --session demo
+```
+
+Cookies past their expiry are dropped on load and on save. Use
+`--clear-session` to wipe the jar before running. `--cookie-jar <path>` is an
+explicit-path escape hatch. The file is rewritten atomically on each run; last
+writer wins across concurrent processes.
+
 ### Jobs
 
 ```bash

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -8,6 +8,7 @@ import { coerceInputsFromSchema } from '../execution/schema-coerce.js';
 import { applyActionDefaults, loadActionDefaults } from '../execution/action-defaults.js';
 import { RunArtifacts } from '../artifacts/run-artifacts.js';
 import { HttpTransportImpl } from '../transport/http.js';
+import { clearCookieJar, loadCookieJar, resolveJarPath, saveCookieJar } from '../transport/cookie-jar-store.js';
 import { getDefaultHttpPoolRegistry } from '../services/http-pool.js';
 import { defaultRuntime } from '../data/run-data.js';
 import { nowIso } from '../core/time.js';
@@ -145,6 +146,9 @@ export function registerRunCommand(
     .option('--base-url <url>', 'HTTP base URL')
     .option('--header <key=value>', 'HTTP header', collectRepeatedOption, [])
     .option('--credential <field=ENV_VAR>', 'Credential field mapping', collectRepeatedOption, [])
+    .option('--session <name>', 'Persist cookies under $DISPATCH_HOME/sessions/<name>/cookies.json')
+    .option('--cookie-jar <path>', 'Persist cookies at an explicit file path')
+    .option('--clear-session', 'Delete the persisted cookie jar before running')
     .action(async (actionKey: string, cmd) => {
       const opts = program.opts<CliOpts>();
       const color = isColorEnabled(opts);
@@ -255,11 +259,46 @@ export function registerRunCommand(
         steps: [buildResolutionRow(step.id, step.action, resolved)],
       });
 
+      let jarPath: ReturnType<typeof resolveJarPath> = null;
+      try {
+        jarPath = resolveJarPath({
+          session: typeof cmd.session === 'string' ? cmd.session : undefined,
+          cookieJar: typeof cmd.cookieJar === 'string' ? cmd.cookieJar : undefined,
+        });
+      } catch (error) {
+        const err = cliErrorFromCode('USAGE_ERROR', error instanceof Error ? error.message : String(error), {
+          action: resolved.actionKey,
+          warnings,
+        });
+        renderer.render({
+          json: jsonErrorEnvelope(err),
+          human: `Error: ${err.message}`,
+        });
+        process.exitCode = exitCodeForCliError(err);
+        return;
+      }
+
+      if (jarPath && cmd.clearSession) clearCookieJar(jarPath.filePath);
+      const initialJar = jarPath ? loadCookieJar(jarPath.filePath) : undefined;
+
+      const poolRegistry = getDefaultHttpPoolRegistry();
       const http = new HttpTransportImpl(artifacts, {
         baseUrl: typeof cmd.baseUrl === 'string' ? cmd.baseUrl : undefined,
         defaultHeaders: headerResult.values,
-        poolRegistry: getDefaultHttpPoolRegistry(),
+        poolRegistry,
+        cookieJar: initialJar,
       });
+
+      const persistJar = (): void => {
+        if (!jarPath) return;
+        try {
+          saveCookieJar(jarPath.filePath, http.getCookieJar());
+        } catch (error) {
+          warnings.push(
+            `Failed to persist cookie jar at ${jarPath.filePath}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      };
 
       const writeSummary = (status: 'SUCCESS' | 'FAILED') => {
         writeJson(path.join(artifacts.runDir, 'summary.json'), {
@@ -295,6 +334,7 @@ export function registerRunCommand(
         }
 
         writeSummary('SUCCESS');
+        persistJar();
         const next = nextActionsForActionRun({ runId: artifacts.runId });
         const summary: ActionRunSummary = {
           ...summaryBase,
@@ -314,6 +354,7 @@ export function registerRunCommand(
         });
       } catch (error) {
         writeSummary('FAILED');
+        persistJar();
         const next = nextActionsForActionRun({ runId: artifacts.runId });
         const code = exitCodeForCliError(error) === 3 ? 'TRANSIENT_ERROR' : 'RUNTIME_ERROR';
         const err = cliErrorFromCode(code, error instanceof Error ? error.message : String(error), {
@@ -331,6 +372,8 @@ export function registerRunCommand(
           ],
         });
         process.exitCode = exitCodeForCliError(err);
+      } finally {
+        await poolRegistry.closeAll();
       }
     });
 }

--- a/src/transport/cookie-jar-store.ts
+++ b/src/transport/cookie-jar-store.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { CookieJar } from './cookies.js';
+import { getDispatchHomeDir } from '../state/home.js';
+
+const SESSION_NAME_PATTERN = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+export interface ResolvedJarPath {
+  filePath: string;
+  source: 'session' | 'cookie-jar';
+  sessionName?: string;
+}
+
+export function resolveJarPath(opts: { session?: string; cookieJar?: string }): ResolvedJarPath | null {
+  const sessionRaw = typeof opts.session === 'string' ? opts.session.trim() : '';
+  const cookieJarRaw = typeof opts.cookieJar === 'string' ? opts.cookieJar.trim() : '';
+
+  if (sessionRaw && cookieJarRaw) {
+    throw new Error('Pass either --session or --cookie-jar, not both');
+  }
+  if (sessionRaw) {
+    if (!SESSION_NAME_PATTERN.test(sessionRaw)) {
+      throw new Error(
+        `Invalid session name '${sessionRaw}'. Use letters, digits, '.', '_' or '-' and start with a letter or digit.`,
+      );
+    }
+    const filePath = path.join(getDispatchHomeDir(), 'sessions', sessionRaw, 'cookies.json');
+    return { filePath, source: 'session', sessionName: sessionRaw };
+  }
+  if (cookieJarRaw) {
+    return { filePath: path.resolve(cookieJarRaw), source: 'cookie-jar' };
+  }
+  return null;
+}
+
+export function loadCookieJar(filePath: string, now = Date.now()): CookieJar {
+  let raw: string;
+  try {
+    raw = fs.readFileSync(filePath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return new CookieJar();
+    throw error;
+  }
+  if (!raw.trim()) return new CookieJar();
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return new CookieJar();
+  }
+  return CookieJar.deserialize(parsed, now);
+}
+
+export function saveCookieJar(filePath: string, jar: CookieJar, now = Date.now()): void {
+  const dir = path.dirname(filePath);
+  fs.mkdirSync(dir, { recursive: true, mode: 0o700 });
+  try {
+    fs.chmodSync(dir, 0o700);
+  } catch {
+    // best-effort on platforms without POSIX perms
+  }
+
+  const data = `${JSON.stringify(jar.serialize(now), null, 2)}\n`;
+  const tmp = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmp, data, { mode: 0o600 });
+  try {
+    fs.chmodSync(tmp, 0o600);
+  } catch {
+    // ignore
+  }
+  fs.renameSync(tmp, filePath);
+  try {
+    fs.chmodSync(filePath, 0o600);
+  } catch {
+    // ignore
+  }
+}
+
+export function clearCookieJar(filePath: string): void {
+  try {
+    fs.unlinkSync(filePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+}

--- a/src/transport/cookies.ts
+++ b/src/transport/cookies.ts
@@ -12,6 +12,13 @@ interface StoredCookie {
   createdAt: number;
 }
 
+export const COOKIE_JAR_FORMAT_VERSION = 1;
+
+export interface SerializedCookieJar {
+  version: number;
+  cookies: StoredCookie[];
+}
+
 export class CookieJar {
   private readonly cookies: StoredCookie[] = [];
 
@@ -40,6 +47,30 @@ export class CookieJar {
 
     if (matching.length === 0) return null;
     return matching.map((cookie) => `${cookie.name}=${cookie.value}`).join('; ');
+  }
+
+  serialize(now = Date.now()): SerializedCookieJar {
+    this.pruneExpired(now);
+    return {
+      version: COOKIE_JAR_FORMAT_VERSION,
+      cookies: this.cookies.map((cookie) => ({ ...cookie })),
+    };
+  }
+
+  static deserialize(input: unknown, now = Date.now()): CookieJar {
+    const jar = new CookieJar();
+    if (!input || typeof input !== 'object') return jar;
+    const record = input as { version?: unknown; cookies?: unknown };
+    if (record.version !== COOKIE_JAR_FORMAT_VERSION) return jar;
+    if (!Array.isArray(record.cookies)) return jar;
+
+    for (const raw of record.cookies) {
+      const cookie = normalizeStoredCookie(raw);
+      if (!cookie) continue;
+      if (cookie.expiresAt !== null && cookie.expiresAt <= now) continue;
+      jar.cookies.push(cookie);
+    }
+    return jar;
   }
 
   private pruneExpired(now: number): void {
@@ -84,6 +115,32 @@ export function mergeCookieHeaders(
   return Array.from(merged.entries())
     .map(([name, value]) => `${name}=${value}`)
     .join('; ');
+}
+
+function normalizeStoredCookie(raw: unknown): StoredCookie | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  if (typeof r.name !== 'string' || !r.name) return null;
+  if (typeof r.value !== 'string') return null;
+  if (typeof r.domain !== 'string' || !r.domain) return null;
+  if (typeof r.path !== 'string' || !r.path) return null;
+  if (typeof r.hostOnly !== 'boolean') return null;
+  if (typeof r.secure !== 'boolean') return null;
+  if (typeof r.httpOnly !== 'boolean') return null;
+  const expiresAt = r.expiresAt === null ? null : typeof r.expiresAt === 'number' ? r.expiresAt : NaN;
+  if (typeof expiresAt === 'number' && Number.isNaN(expiresAt)) return null;
+  const createdAt = typeof r.createdAt === 'number' ? r.createdAt : Date.now();
+  return {
+    name: r.name,
+    value: r.value,
+    domain: r.domain,
+    hostOnly: r.hostOnly,
+    path: r.path,
+    secure: r.secure,
+    httpOnly: r.httpOnly,
+    expiresAt,
+    createdAt,
+  };
 }
 
 function parseSetCookie(raw: string, url: URL): StoredCookie | null {

--- a/src/transport/http.ts
+++ b/src/transport/http.ts
@@ -39,6 +39,7 @@ interface HttpTransportConfig {
   defaultHeaders?: Record<string, string>;
   verboseArtifacts?: boolean;
   poolRegistry?: ConnectionPoolProvider;
+  cookieJar?: CookieJar;
 }
 
 interface HttpTransportSharedState {
@@ -62,9 +63,13 @@ export class HttpTransportImpl implements HttpTransport {
     private readonly opts?: HttpTransportConfig,
   ) {
     this.shared = {
-      cookieJar: new CookieJar(),
+      cookieJar: opts?.cookieJar ?? new CookieJar(),
       poolRegistry: opts?.poolRegistry,
     };
+  }
+
+  getCookieJar(): CookieJar {
+    return this.shared.cookieJar;
   }
 
   /**

--- a/test/cookie-jar-serialize.test.ts
+++ b/test/cookie-jar-serialize.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { COOKIE_JAR_FORMAT_VERSION, CookieJar } from '../src/transport/cookies.ts';
+
+function buildJar(headers: Record<string, string[]>, url = 'https://example.com/login') {
+  const jar = new CookieJar();
+  jar.storeFromResponse(new URL(url), headers);
+  return jar;
+}
+
+describe('CookieJar.serialize / deserialize', () => {
+  it('round-trips a session cookie unchanged', () => {
+    const jar = buildJar({ 'set-cookie': ['sid=abc123; Path=/; HttpOnly'] });
+    const dumped = jar.serialize();
+    expect(dumped.version).toBe(COOKIE_JAR_FORMAT_VERSION);
+
+    const restored = CookieJar.deserialize(JSON.parse(JSON.stringify(dumped)));
+    expect(restored.getCookieHeader(new URL('https://example.com/me'))).toBe('sid=abc123');
+  });
+
+  it('round-trips an explicitly-domained cookie', () => {
+    const jar = buildJar({
+      'set-cookie': ['theme=dark; Domain=example.com; Path=/'],
+    });
+    const restored = CookieJar.deserialize(jar.serialize());
+    expect(restored.getCookieHeader(new URL('https://api.example.com/x'))).toBe('theme=dark');
+  });
+
+  it('drops cookies whose expiresAt is in the past when loading', () => {
+    const now = Date.now();
+    const payload = {
+      version: COOKIE_JAR_FORMAT_VERSION,
+      cookies: [
+        {
+          name: 'stale',
+          value: 'x',
+          domain: 'example.com',
+          hostOnly: true,
+          path: '/',
+          secure: false,
+          httpOnly: false,
+          expiresAt: now - 1000,
+          createdAt: now - 5000,
+        },
+        {
+          name: 'fresh',
+          value: 'y',
+          domain: 'example.com',
+          hostOnly: true,
+          path: '/',
+          secure: false,
+          httpOnly: false,
+          expiresAt: now + 60_000,
+          createdAt: now,
+        },
+      ],
+    };
+    const restored = CookieJar.deserialize(payload, now);
+    expect(restored.getCookieHeader(new URL('https://example.com/'))).toBe('fresh=y');
+  });
+
+  it('drops expired cookies on serialize', () => {
+    const jar = new CookieJar();
+    jar.storeFromResponse(new URL('https://example.com/'), {
+      'set-cookie': ['stale=x; Max-Age=1; Path=/', 'fresh=y; Path=/'],
+    });
+    const future = Date.now() + 10_000;
+    const dumped = jar.serialize(future);
+    const names = dumped.cookies.map((c) => c.name);
+    expect(names).toContain('fresh');
+    expect(names).not.toContain('stale');
+  });
+
+  it('returns an empty jar for unknown version', () => {
+    const restored = CookieJar.deserialize({ version: 999, cookies: [] });
+    expect(restored.getCookieHeader(new URL('https://example.com/'))).toBeNull();
+  });
+
+  it('returns an empty jar for malformed input', () => {
+    expect(CookieJar.deserialize(null).getCookieHeader(new URL('https://example.com/'))).toBeNull();
+    expect(CookieJar.deserialize('garbage').getCookieHeader(new URL('https://example.com/'))).toBeNull();
+    expect(
+      CookieJar.deserialize({ version: COOKIE_JAR_FORMAT_VERSION, cookies: 'nope' }).getCookieHeader(
+        new URL('https://example.com/'),
+      ),
+    ).toBeNull();
+  });
+
+  it('skips entries missing required fields', () => {
+    const restored = CookieJar.deserialize({
+      version: COOKIE_JAR_FORMAT_VERSION,
+      cookies: [
+        { name: 'ok', value: 'v', domain: 'example.com', hostOnly: true, path: '/', secure: false, httpOnly: false, expiresAt: null, createdAt: 0 },
+        { name: 'bad' },
+        { value: 'noname' },
+      ],
+    });
+    expect(restored.getCookieHeader(new URL('https://example.com/'))).toBe('ok=v');
+  });
+});

--- a/test/cookie-jar-store.test.ts
+++ b/test/cookie-jar-store.test.ts
@@ -1,0 +1,116 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { CookieJar } from '../src/transport/cookies.ts';
+import {
+  clearCookieJar,
+  loadCookieJar,
+  resolveJarPath,
+  saveCookieJar,
+} from '../src/transport/cookie-jar-store.ts';
+import { setDispatchHomeOverride } from '../src/state/home.ts';
+
+let tmp: string;
+
+beforeEach(() => {
+  tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-jar-store-'));
+  setDispatchHomeOverride(tmp);
+});
+
+afterEach(() => {
+  setDispatchHomeOverride(null);
+  fs.rmSync(tmp, { recursive: true, force: true });
+});
+
+describe('resolveJarPath', () => {
+  it('returns null when neither flag passed', () => {
+    expect(resolveJarPath({})).toBeNull();
+  });
+
+  it('expands --session under DISPATCH_HOME/sessions/<name>/cookies.json', () => {
+    const resolved = resolveJarPath({ session: 'demo' });
+    expect(resolved?.filePath).toBe(path.join(tmp, 'sessions', 'demo', 'cookies.json'));
+    expect(resolved?.source).toBe('session');
+  });
+
+  it('takes --cookie-jar as an absolute file path', () => {
+    const target = path.join(tmp, 'custom.json');
+    const resolved = resolveJarPath({ cookieJar: target });
+    expect(resolved?.filePath).toBe(target);
+    expect(resolved?.source).toBe('cookie-jar');
+  });
+
+  it('rejects both flags together', () => {
+    expect(() => resolveJarPath({ session: 'a', cookieJar: 'b' })).toThrow(/either --session or --cookie-jar/);
+  });
+
+  it('rejects unsafe session names', () => {
+    expect(() => resolveJarPath({ session: '../escape' })).toThrow(/Invalid session name/);
+    expect(() => resolveJarPath({ session: 'with/slash' })).toThrow(/Invalid session name/);
+    expect(() => resolveJarPath({ session: '' })).toBeTruthy(); // empty returns null
+  });
+});
+
+describe('loadCookieJar / saveCookieJar', () => {
+  it('returns an empty jar when the file does not exist', () => {
+    const jar = loadCookieJar(path.join(tmp, 'missing.json'));
+    expect(jar.getCookieHeader(new URL('https://example.com/'))).toBeNull();
+  });
+
+  it('round-trips through disk', () => {
+    const jar = new CookieJar();
+    jar.storeFromResponse(new URL('https://example.com/login'), {
+      'set-cookie': ['sid=abc123; Path=/; HttpOnly'],
+    });
+    const target = path.join(tmp, 'sessions', 'demo', 'cookies.json');
+    saveCookieJar(target, jar);
+
+    const restored = loadCookieJar(target);
+    expect(restored.getCookieHeader(new URL('https://example.com/me'))).toBe('sid=abc123');
+  });
+
+  it('writes the file mode 0600 and the directory 0700', () => {
+    if (process.platform === 'win32') return;
+    const jar = new CookieJar();
+    jar.storeFromResponse(new URL('https://example.com/'), {
+      'set-cookie': ['sid=abc; Path=/'],
+    });
+    const target = path.join(tmp, 'sessions', 'demo', 'cookies.json');
+    saveCookieJar(target, jar);
+
+    expect(fs.statSync(target).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(path.dirname(target)).mode & 0o777).toBe(0o700);
+  });
+
+  it('atomic-writes via a temp file', () => {
+    const target = path.join(tmp, 'cookies.json');
+    fs.writeFileSync(target, 'pre-existing');
+    const jar = new CookieJar();
+    jar.storeFromResponse(new URL('https://example.com/'), { 'set-cookie': ['sid=new; Path=/'] });
+    saveCookieJar(target, jar);
+    expect(fs.readFileSync(target, 'utf8')).toContain('"sid"');
+    const remaining = fs.readdirSync(path.dirname(target)).filter((f) => f.startsWith('cookies.json.tmp'));
+    expect(remaining).toEqual([]);
+  });
+
+  it('ignores malformed JSON and starts empty', () => {
+    const target = path.join(tmp, 'cookies.json');
+    fs.writeFileSync(target, '{not json');
+    const jar = loadCookieJar(target);
+    expect(jar.getCookieHeader(new URL('https://example.com/'))).toBeNull();
+  });
+});
+
+describe('clearCookieJar', () => {
+  it('removes the file when present', () => {
+    const target = path.join(tmp, 'cookies.json');
+    fs.writeFileSync(target, '{}');
+    clearCookieJar(target);
+    expect(fs.existsSync(target)).toBe(false);
+  });
+
+  it('is a no-op when the file is missing', () => {
+    expect(() => clearCookieJar(path.join(tmp, 'absent.json'))).not.toThrow();
+  });
+});

--- a/test/run-session.test.ts
+++ b/test/run-session.test.ts
@@ -1,0 +1,173 @@
+import http from 'node:http';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+
+const THIS_DIR = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(THIS_DIR, '..');
+const SDK_IMPORT = JSON.stringify(pathToFileURL(path.join(REPO_ROOT, 'src', 'index.ts')).href);
+const ZOD_IMPORT = JSON.stringify(pathToFileURL(path.join(REPO_ROOT, 'node_modules', 'zod', 'index.js')).href);
+const FIXTURE_NAME = `zz-session-fixture-${process.pid}`;
+const FIXTURE_DIR = path.join(REPO_ROOT, 'modules', FIXTURE_NAME);
+
+interface RecordedRequest {
+  url: string;
+  cookie: string | undefined;
+}
+
+let server: http.Server;
+let baseUrl: string;
+const recorded: RecordedRequest[] = [];
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    recorded.push({ url: req.url ?? '', cookie: req.headers.cookie });
+    if (req.url === '/login') {
+      res.setHeader('Set-Cookie', 'session=abc; Path=/; HttpOnly');
+      res.setHeader('Content-Type', 'application/json');
+      res.end('{"ok":true}');
+      return;
+    }
+    res.setHeader('Content-Type', 'application/json');
+    res.end(JSON.stringify({ saw: req.headers.cookie ?? null }));
+  });
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const addr = server.address();
+  if (!addr || typeof addr === 'string') throw new Error('failed to bind test server');
+  baseUrl = `http://127.0.0.1:${addr.port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+function writeFixture(): void {
+  fs.mkdirSync(FIXTURE_DIR, { recursive: true });
+  fs.writeFileSync(
+    path.join(FIXTURE_DIR, 'module.json'),
+    `${JSON.stringify({ name: FIXTURE_NAME, version: '1.0.0', entry: 'index.mjs' }, null, 2)}\n`,
+    'utf8',
+  );
+  fs.writeFileSync(
+    path.join(FIXTURE_DIR, 'index.mjs'),
+    [
+      `import { defineAction, defineModule } from ${SDK_IMPORT};`,
+      `import { z } from ${ZOD_IMPORT};`,
+      'export default defineModule({',
+      `  name: '${FIXTURE_NAME}',`,
+      "  version: '1.0.0',",
+      '  actions: {',
+      "    login: defineAction({",
+      "      description: 'Hit login endpoint to receive a session cookie.',",
+      '      schema: z.object({}),',
+      "      handler: async (ctx) => {",
+      "        const resp = await ctx.http.get('/login');",
+      "        return { response: resp.body, detail: 'ok' };",
+      '      },',
+      '    }),',
+      "    ping: defineAction({",
+      "      description: 'Hit a protected endpoint reusing the cookie jar.',",
+      '      schema: z.object({}),',
+      "      handler: async (ctx) => {",
+      "        const resp = await ctx.http.get('/ping');",
+      "        return { response: resp.body, detail: 'ok' };",
+      '      },',
+      '    }),',
+      '  },',
+      '});',
+    ].join('\n'),
+    'utf8',
+  );
+}
+
+async function runCli(args: string[], env: NodeJS.ProcessEnv): Promise<{
+  status: number | null;
+  stdout: string;
+  stderr: string;
+  json: any;
+}> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(
+      process.execPath,
+      ['--import', 'tsx', 'src/cli.ts', '--json', ...args],
+      { cwd: REPO_ROOT, env: { ...process.env, ...env } },
+    );
+    const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    child.stdout.on('data', (d) => stdoutChunks.push(d));
+    child.stderr.on('data', (d) => stderrChunks.push(d));
+    const timeoutHandle = setTimeout(() => {
+      child.kill('SIGKILL');
+    }, 20000);
+    child.on('error', reject);
+    child.on('close', (status) => {
+      clearTimeout(timeoutHandle);
+      const stdout = Buffer.concat(stdoutChunks).toString('utf8').trim();
+      const stderr = Buffer.concat(stderrChunks).toString('utf8');
+      resolve({
+        status,
+        stdout,
+        stderr,
+        json: stdout ? JSON.parse(stdout) : null,
+      });
+    });
+  });
+}
+
+afterEach(() => {
+  recorded.length = 0;
+  fs.rmSync(FIXTURE_DIR, { recursive: true, force: true });
+});
+
+describe('dispatch run --session', () => {
+  it('persists cookies between invocations and reuses them on the next request', async () => {
+    writeFixture();
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-session-'));
+    try {
+      const login = await runCli(
+        ['run', `${FIXTURE_NAME}.login`, '--base-url', baseUrl, '--session', 'test-roundtrip'],
+        { DISPATCH_HOME: home },
+      );
+      expect(login.status).toBe(0);
+      expect(login.json?.status).toBe('SUCCESS');
+
+      const jarPath = path.join(home, 'sessions', 'test-roundtrip', 'cookies.json');
+      expect(fs.existsSync(jarPath)).toBe(true);
+      const dumped = JSON.parse(fs.readFileSync(jarPath, 'utf8'));
+      expect(dumped.version).toBe(1);
+      expect(dumped.cookies).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'session', value: 'abc' })]),
+      );
+
+      const ping = await runCli(
+        ['run', `${FIXTURE_NAME}.ping`, '--base-url', baseUrl, '--session', 'test-roundtrip'],
+        { DISPATCH_HOME: home },
+      );
+      expect(ping.status).toBe(0);
+      const protectedCall = recorded.find((entry) => entry.url === '/ping');
+      expect(protectedCall?.cookie).toBe('session=abc');
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps the jar ephemeral when --session is not passed', async () => {
+    writeFixture();
+    const home = fs.mkdtempSync(path.join(os.tmpdir(), 'dispatch-session-'));
+    try {
+      const login = await runCli(['run', `${FIXTURE_NAME}.login`, '--base-url', baseUrl], { DISPATCH_HOME: home });
+      expect(login.status).toBe(0);
+      expect(fs.existsSync(path.join(home, 'sessions'))).toBe(false);
+
+      const ping = await runCli(['run', `${FIXTURE_NAME}.ping`, '--base-url', baseUrl], { DISPATCH_HOME: home });
+      expect(ping.status).toBe(0);
+      const protectedCall = recorded.find((entry) => entry.url === '/ping');
+      expect(protectedCall?.cookie).toBeUndefined();
+    } finally {
+      fs.rmSync(home, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `--session <name>` / `--cookie-jar <path>` flags on `dispatch run` persist cookies across invocations so a one-shot login call can hand its session to follow-up reads.
- New `CookieJar.serialize` / `CookieJar.deserialize` with a versioned JSON format. Expired cookies are dropped on both load and save.
- Persistence layer writes atomically via a tmp file + rename. File mode `0600`, dir `0700`. `--clear-session` wipes the jar before running.
- `dispatch run` now closes the default HTTP pool registry on exit so the CLI terminates promptly after real requests.

## Test plan
- [x] `npx vitest run` — 249 tests pass (workspace tests only; stale worktree under `.claude/worktrees/` excluded).
- [x] `npx tsc --noEmit` — clean.
- [x] New unit tests for serialize/deserialize round-trip + expiry filtering.
- [x] New unit tests for `loadCookieJar` / `saveCookieJar` covering atomic write, file mode `0600`, dir mode `0700`, malformed-JSON fallback, and `--session` name validation.
- [x] New integration test: real local server issues `Set-Cookie: session=abc`, jar lands at `$DISPATCH_HOME/sessions/test-roundtrip/cookies.json`, second `dispatch run` with the same `--session` sends `Cookie: session=abc`.
- [x] README documents the flag with a placeholder-named login + reuse example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)